### PR TITLE
Add python-dateutil dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     description="An API for parsing and generating CybOX content.",
     url="http://cybox.mitre.org",
     packages=find_packages(),
-    install_requires=['lxml>=2.3'],
+    install_requires=['lxml>=2.3', 'python-dateutil'],
     classifiers=[
         "Programming Language :: Python",
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Please add `python-dateutil` dependency in `setup.py`. 

Dateutil is used at `python-cybox/cybox/common/attributes.py:383`
