### PR TITLE
corrected dependency package name in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ The ``cybox`` package depends on the following Python libraries:
 
 * ``lxml`` >= 3.1.x
 
-* ``python-dateutils``
+* ``python-dateutil``
 
 * ``setuptools`` (only if installing using setup.py)
 


### PR DESCRIPTION
This is a small thing, but "python-dateutils" (note the "s") refers to something else (https://github.com/jmcantrell/python-dateutils), which got me off on the wrong track while attempting to package this for a different package management system.
