### PR TITLE
adding a from_json() method to the python-cybox base class;

### DIFF
--- a/cybox/__init__.py
+++ b/cybox/__init__.py
@@ -15,7 +15,16 @@ class Entity(object):
         return s.getvalue()
 
     def to_json(self):
+        '''serialize object to json'''
         return json.dumps(self.to_dict())
+
+    def from_json(self, json_doc):
+        '''deserialize object from json'''
+        try:
+            d = json.load(json_doc)
+        except AttributeError: # catch the read() error
+            d = json.loads(json_doc)
+        return self.from_dict(d)
 
     @classmethod
     def object_from_dict(cls, entity_dict):


### PR DESCRIPTION
This fixes python-cybox issue #168 - 'add a from_json() method to Entity baseclass'
