### PR TITLE
adding a from_json() method to the python-cybox base class;

### DIFF
--- a/cybox/__init__.py
+++ b/cybox/__init__.py
@@ -233,9 +233,16 @@ class Entity(object):
         return s.getvalue().strip()
 
     def to_json(self):
-        """Export an object as a JSON string.
-        """
+        '''serialize object to json'''
         return json.dumps(self.to_dict())
+
+    def from_json(self, json_doc):
+        '''deserialize object from json'''
+        try:
+            d = json.load(json_doc)
+        except AttributeError: # catch the read() error
+            d = json.loads(json_doc)
+        return self.from_dict(d)
 
     def _get_namespace_def(self, additional_ns_dict=None):
         # copy necessary namespaces


### PR DESCRIPTION
This fixes python-cybox issue #168 - 'add a from_json() method to Entity baseclass'
