### PR TITLE
Add Keywords to Observable

### DIFF
--- a/cybox/core/observable.py
+++ b/cybox/core/observable.py
@@ -40,7 +40,7 @@ class Observable(cybox.Entity):
         self.idref = idref
         self.sighting_count = None
         self.observable_source = []
-        self.keywords = core_binding.KeywordsType()
+        self.keywords = Keywords()
 
         if not item:
             return
@@ -143,11 +143,8 @@ class Observable(cybox.Entity):
             value = StructuredText(value)
         self._description = value
 
-    def get_keywords(self):
-        return self.keywords
-
     def add_keyword(self, value):
-        self.keywords.add_Keyword(value)
+        self.keywords.append(value)
 
     def to_obj(self):
         obs_obj = core_binding.ObservableType()
@@ -170,8 +167,8 @@ class Observable(cybox.Entity):
         if self.observable_source:
             obs_obj.set_Observable_Source([x.to_obj() for x in self.observable_source])
         if self.keywords:
-            obs_obj.Keywords = self.keywords
-        
+            obs_obj.set_Keywords(self.keywords.to_obj())
+
         return obs_obj
 
     def to_dict(self):
@@ -196,7 +193,7 @@ class Observable(cybox.Entity):
         if self.observable_source:
             obs_dict['observable_source'] = [x.to_dict() for x in self.observable_source]
         if self.keywords:
-            obs_dict['keywords'] = self.keywords.get_Keyword()
+            obs_dict['keywords'] = self.keywords.to_dict()
 
         return obs_dict
 
@@ -217,6 +214,8 @@ class Observable(cybox.Entity):
         obs.sighting_count = observable_obj.get_sighting_count()
         if observable_obj.get_Observable_Source():
             obs.observable_source = [MeasureSource.from_obj(x) for x in observable_obj.get_Observable_Source()]
+        obs.keywords = Keywords.from_obj(observable_obj.get_Keywords())
+
         return obs
 
     @staticmethod
@@ -236,6 +235,7 @@ class Observable(cybox.Entity):
         obs.sighting_count = observable_dict.get('sighting_count')
         if observable_dict.get('observable_source'):
             obs.observable_source = [MeasureSource.from_dict(x) for x in observable_dict.get('observable_source')]
+        obs.keywords = Keywords.from_dict(observable_dict.get('keywords'))
 
         return obs
 
@@ -409,3 +409,11 @@ class ObservableComposition(cybox.Entity):
             obs_comp.add(Observable.from_dict(o))
 
         return obs_comp
+
+
+class Keywords(cybox.EntityList):
+    _binding = core_binding
+    _binding_class = core_binding.KeywordsType
+    _binding_var = "Keyword"
+    _contained_type = cybox.Unicode
+    _namespace = 'http://cybox.mitre.org/cybox-2'

--- a/cybox/test/core/observable_test.py
+++ b/cybox/test/core/observable_test.py
@@ -16,6 +16,10 @@ class TestObservable(EntityTestCase, unittest.TestCase):
         'id': "example:Observable-1",
         'title': "An Observable",
         'description': "A longer description of the observable",
+        'keywords': [
+            "DANGER!",
+            "External",
+        ],
         'object': {
             'properties': {
                 'file_name': u"example.txt",
@@ -27,6 +31,18 @@ class TestObservable(EntityTestCase, unittest.TestCase):
             'name': "ObservingTool",
         }],
     }
+
+    def test_keywords(self):
+        o = Observable()
+        o.title = "Test"
+
+        self.assertTrue("eyword" not in o.to_xml())
+        o.add_keyword("Foo")
+        print o.to_xml()
+        self.assertTrue("<cybox:Keyword>Foo</cybox:Keyword>" in o.to_xml())
+
+        o2 = round_trip(o)
+        self.assertEqual(1, len(o2.keywords))
 
     def test_observable_id(self):
         o = Observable()


### PR DESCRIPTION
@wick2o I wasn't able to push a new commit to your branch, so I copied it to a branch locally. I'm going to merge this, but it shows the standard way of adding a new field to a class in python-cybox. Hopefully it's useful  if you want to add other fields in the future.
