### PR TITLE
Let Observables behave more like a list.

### DIFF
--- a/cybox/core/observable.py
+++ b/cybox/core/observable.py
@@ -254,12 +254,13 @@ class Observable(cybox.Entity):
         return obs
 
 
-class Observables(cybox.Entity):
+class Observables(cybox.EntityList):
     """The root CybOX Observables object.
 
     Pools are not currently supported.
     """
     _binding = core_binding
+    _contained_type = Observable
     _namespace = 'http://cybox.mitre.org/cybox-2'
 
     def __init__(self, observables=None):
@@ -279,12 +280,12 @@ class Observables(cybox.Entity):
             self.add(observables)
 
     @property
-    def __iter__(self):
-        return self.observables.__iter__
+    def observables(self):
+        return self._inner
 
-    @property
-    def __len__(self):
-        return self.observables.__len__
+    @observables.setter
+    def observables(self, value):
+        self._inner = value
 
     def add(self, observable):
         if not observable:

--- a/cybox/test/core/observable_test.py
+++ b/cybox/test/core/observable_test.py
@@ -194,7 +194,50 @@ def _set_event(observable, event):
     observable.event = event
 
 
-class ObservablesTest(unittest.TestCase):
+class TestObservables(EntityTestCase, unittest.TestCase):
+    klass = Observables
+    _full_dict = {
+        'major_version': 2,
+        'minor_version': 1,
+        'update_version': 0,
+        'observables': [
+            {
+                'id': "example:Observable-1",
+                'title': "An Observable",
+                'description': "A longer description of the observable",
+                'object': {
+                    'properties': {
+                        'file_name': u"example.txt",
+                        'xsi:type': "FileObjectType"
+                    },
+                },
+            }
+        ],
+        'observable_package_source': {
+            'name': "The Source",
+            'information_source_type': u"Logs",
+        },
+    }
+
+    # https://github.com/CybOXProject/python-cybox/issues/232
+    def test_list_behavior(self):
+        obs = Observables.from_dict(self._full_dict)
+
+        self.assertEqual(1, len(obs))
+        self.assertTrue(obs[0] is not None)
+        self.assertRaises(IndexError, obs.__getitem__, 1)
+        self.assertEqual("example.txt", obs[0].object_.properties.file_name)
+
+        self.assertEqual(self._full_dict, obs.to_dict())
+        # When calling to_list, only the observables themselves are returned.
+        self.assertEqual(self._full_dict['observables'], obs.to_list())
+
+        # Even when using append, an Address automatically gets wrapped in an
+        # Object and an Observable.
+        obs.append(Address("test@example.com", Address.CAT_EMAIL))
+        self.assertEqual(2, len(obs))
+        self.assertEqual(Observable, type(obs[1]))
+        self.assertEqual(Address.CAT_EMAIL, obs[1].object_.properties.category)
 
     def test_round_trip(self):
         a = Address("test@example.com", Address.CAT_EMAIL)


### PR DESCRIPTION
- Have Observables subclass EntityList rather than Entity.
- Set contained_type to Observable.

There is still quite a bit of customized code in Observables, but this is
enough to fix #232.