### PR TITLE
Iterating TypedFields cleanup

### DIFF
--- a/cybox/test/__init__.py
+++ b/cybox/test/__init__.py
@@ -53,7 +53,7 @@ def assert_entity_equals(entity, other, name=None):
 
     assert type(entity) == type(other)
 
-    for var in entity.__class__._get_vars():
+    for var in entity.typed_fields:
         # Recursion!
         assert_entity_equals(getattr(entity, var.attr_name),
                              getattr(other, var.attr_name),

--- a/cybox/test/objects/email_message_test.py
+++ b/cybox/test/objects/email_message_test.py
@@ -127,7 +127,7 @@ class TestEmailRecipients(unittest.TestCase):
     def test_invalid_recip_type(self):
         ipv4 = Address("1.2.3.4", Address.CAT_IPV4)
         generic_address = Address("aaaa")
-        for a in [dict(a=1), 1, True, [1], ipv4, generic_address]:
+        for a in [{1: 'a'}, 1, True, [1], ipv4, generic_address]:
             self.assertRaises(ValueError, EmailRecipients, a)
 
 

--- a/cybox/version.py
+++ b/cybox/version.py
@@ -1,4 +1,4 @@
 # Copyright (c) 2015, The MITRE Corporation. All rights reserved.
 # See LICENSE.txt for complete terms.
 
-__version__ = "2.1.0.12.dev2"
+__version__ = "2.1.0.13.dev0"

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open('README.rst') as f:
 
 install_requires = [
     'lxml>=2.2.3',
-    'mixbox>=0.0.8',
+    'mixbox>=0.0.11',
     'python-dateutil',
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ commands =
     nosetests cybox --exclude=ciq_test.py
 deps =
     lxml==2.2.3
-    mixbox==0.0.8
+    mixbox==0.0.11
     python-dateutil==1.4.1
     nose
 


### PR DESCRIPTION
This is the related pull request to the CybOXProject/mixbox#16 pull request.  A one-liner change to use the Entity.typed_fields property.