### PR TITLE
Remove attr name

### DIFF
--- a/cybox/objects/win_file_object.py
+++ b/cybox/objects/win_file_object.py
@@ -41,7 +41,7 @@ class WindowsFileAttributes(FileAttribute, entities.EntityList):
     _namespace = 'http://cybox.mitre.org/objects#WinFileObject-2'
 
 
-class WindowsFilePermissions(FilePermissions, entities.Entity):
+class WindowsFilePermissions(FilePermissions):
     _binding = win_file_binding
     _binding_class = win_file_binding.WindowsFilePermissionsType
     _namespace = 'http://cybox.mitre.org/objects#WinFileObject-2'
@@ -73,4 +73,12 @@ class WinFile(File):
     #Override abstract types
     file_attributes_list = fields.TypedField('File_Attributes_List',
                                             WindowsFileAttributes)
-    privilege_list = fields.TypedField('Permissions', WindowsFilePermissions)
+    permissions = fields.TypedField('Permissions', WindowsFilePermissions)
+
+    @property
+    def privilege_list(self):
+        return self.permissions
+
+    @privilege_list.setter
+    def privilege_list(self, value):
+        self.permissions = value

--- a/cybox/test/__init__.py
+++ b/cybox/test/__init__.py
@@ -55,9 +55,11 @@ def assert_entity_equals(entity, other, name=None):
 
     for var in entity.typed_fields:
         # Recursion!
-        assert_entity_equals(getattr(entity, var.attr_name),
-                             getattr(other, var.attr_name),
-                             name=var)
+        assert_entity_equals(
+            var.__get__(entity),
+            var.__get__(other),
+            name=var
+        )
 
 
 def round_trip(o, output=False, list_=False):


### PR DESCRIPTION
This is the other half to https://github.com/CybOXProject/mixbox/pull/17 and includes changes to code that leveraged `attr_name`.

The `WinFile` changes:
* `WindowsFilePermissions` already inherited from `Entity` via `FilePermissions`, so I removed it.
* The `privilege_list` field seemed like maybe a mistake, or perhaps a rewording to fit the Windows nomenclature. Anyway, `inspect.getmembers()` reported two `TypedField` for the "Permissions" field which caused some funny behaviors in the unit tests, so I just removed it and overrode the `File.permissions` field. Added a property for backward compat.