### PR TITLE
Implement __hash__() for BaseProperty object.

### DIFF
--- a/cybox/common/properties.py
+++ b/cybox/common/properties.py
@@ -157,6 +157,9 @@ class BaseProperty(PatternFieldGroup, entities.Entity):
             self.trend == other.trend
         )
 
+    def __hash__(self):
+        return super(BaseProperty, self).__hash__()
+
     def __ne__(self, other):
         return not self == other
 

--- a/cybox/common/properties.py
+++ b/cybox/common/properties.py
@@ -56,6 +56,8 @@ class ListLongField(ListFieldMixin, fields.LongField): pass
 
 @six.python_2_unicode_compatible
 class BaseProperty(PatternFieldGroup, entities.Entity):
+    __hash__ = entities.Entity.__hash__
+
     # Most Properties are defined in the "common" binding, so we'll just set
     # that here. Some BaseProperty subclasses might have to override this.
     _binding = common_binding
@@ -156,9 +158,6 @@ class BaseProperty(PatternFieldGroup, entities.Entity):
             self.has_changed == other.has_changed and
             self.trend == other.trend
         )
-
-    def __hash__(self):
-        return super(BaseProperty, self).__hash__()
 
     def __ne__(self, other):
         return not self == other

--- a/cybox/common/vocabs.py
+++ b/cybox/common/vocabs.py
@@ -85,6 +85,8 @@ class VocabField(fields.TypedField):
 
 
 class VocabString(PatternFieldGroup, entities.Entity):
+    __hash__ = entities.Entity.__hash__
+
     _namespace = 'http://cybox.mitre.org/default_vocabularies-2'
     # All subclasses should override this
     _XSI_TYPE = None


### PR DESCRIPTION
Related to issue #288. Implemented __hash__() by calling super class hash method defined in entities.Entity.

**Note: Update setup.py requirement to mixbox next release version (1.0.2) before merging.**
